### PR TITLE
Debug now display the body of function

### DIFF
--- a/src/lang/function.rs
+++ b/src/lang/function.rs
@@ -88,7 +88,7 @@ impl fmt::Debug for ConcreteFunction {
                 write!(f, ", {:?}", arg)?;
             }
         }
-        write!(f, ") -> {}", self.ret.print_to_string())
+        write!(f, ") -> {}, {:?}", self.ret.print_to_string(), self.body)
     }
 }
 


### PR DESCRIPTION
New Display Debug Parser:

`FunctionDef(prototype, body)`